### PR TITLE
Chem-whiz removal

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -141,9 +141,6 @@
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>The legion has no use for drugs! Better to destroy it.</span>")
 		return
-	if(!user.mind.ischemwhiz==TRUE)
-		to_chat(user, "<span class='warning'>Try as you might, you have no clue how to work this thing.</span>")
-		return
 	if(!ui)
 		ui = new(user, src, ui_key, "chem_dispenser", name, 550, 550, master_ui, state)
 		if(user.hallucinating())


### PR DESCRIPTION
## Description
Literally just gets rid of chem whiz so anyone can use chem machines.

## Motivation and Context
Chem whiz is bad and broken. 

## How Has This Been Tested?
It works, tested it on BD when I was changing it on there. 

## Screenshots (if appropriate):

## Changelog (neccesary)
:cl:

del: Removes Chem whiz. 

/:cl:
